### PR TITLE
Enable "next button" if step is completed.

### DIFF
--- a/src/HorizontalStepper.vue
+++ b/src/HorizontalStepper.vue
@@ -151,6 +151,11 @@ export default {
         if (!back) {
           this.$emit("completed-step", this.previousStep);
         }
+        
+        if(this.steps[index].completed) {
+          this.canContinue = true;
+        }
+        
       }
       this.$emit("active-step", this.currentStep);
     },


### PR DESCRIPTION
I must allow the users to review the previous steps of a form. 
Since the "can-continue" event is only triggered by Vee Validate, if the form is correct the user must be able to continue after going back for a check and deciding not to make changes at all.

I